### PR TITLE
Add design-sync inputs for claude.ai/design import

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,69 @@
+# design-sync notes — simon-chen-website
+
+Repo-specific gotchas for syncing this design system to claude.ai/design.
+Project: **Simon Chen Website DS** (`1946e533-a140-4dd6-8579-51826a9a102c`).
+
+## Shape & scope
+- This is a **Vite app, not a published component library** — no `dist`, no
+  `module`/`main`/`exports`, no types. Runs in the converter's **synth-entry**
+  territory, but with a hand-written entry (below).
+- Synced scope is intentionally just **5 UI components**: `Button`, `Card`,
+  `Tag`, `FormField` (group `general`) and `RatingGraph` (group `charts`). The
+  app has many more components (Hero, Navbar, About, …) deliberately left out —
+  they're app-specific compositions, not reusable DS parts. To add one, extend
+  `cfg.componentSrcMap` and re-export it from `.design-sync/entry.jsx`.
+
+## Custom barrel entry (load-bearing)
+- The components use `export default`, which `export *` (the synth-entry
+  default) does **not** re-export — so the auto entry would discover them but
+  leave `window.SimonChenWebsite.<Name>` undefined. `.design-sync/entry.jsx`
+  re-exports each default as a **named** export, plus `ThemeProvider`. Pinned
+  via `cfg.entry`. Discovery is driven by `cfg.componentSrcMap` (the .d.ts scan
+  finds nothing). If you add a component, do BOTH.
+
+## CSS (must be flattened)
+- `src/styles/index.css` is a tree of relative `@import`s; the converter copies
+  `cfg.cssEntry` verbatim to the bundle root, where those relatives would
+  dangle. `cfg.buildCmd` = `node .design-sync/build-css.mjs` esbuild-bundles it
+  into `.design-sync/styles.bundled.css` (gitignored) with global class names
+  intact. **The driver runs `cfg.buildCmd` before the converter** — if you ever
+  run `package-build.mjs` directly, run build-css.mjs first.
+- Tokens live in `:root` (light theme is the default), so components render
+  styled even without a theme class. `_ds_bundle.css` carries everything;
+  `tokens/` and `fonts/` are empty by design.
+
+## Fonts
+- Brand fonts **Fraunces** + **JetBrains Mono** load from **Google Fonts** at
+  runtime — the app links them in `index.html`, not via CSS. `build-css.mjs`
+  prepends a `@import url(fonts.googleapis…)` so the styles closure loads them.
+  Validate prints `[FONT_REMOTE]` (expected) — NOT `[FONT_MISSING]`.
+
+## Provider
+- `cfg.provider = ThemeProvider`. `RatingGraph` reads `useTheme()` and **throws
+  without it**; the other four don't need it but are wrapped harmlessly.
+
+## Previews
+- `RatingGraph.tsx` overrides `requestAnimationFrame` so recharts' line
+  animation settles to its final frame under the capture harness's frozen
+  clock (verified: the live card animates fine in a real browser without it).
+- `dtsPropsFor` is hand-written for all 5 (synth mode has no types).
+- `cfg.guidelinesGlob = []` — the repo's `docs/*.md` are developer docs
+  (architecture, API notes, old README), not design guidance; excluded.
+
+## Known render warns (recorded — not new)
+- `[FONT_REMOTE]` "Fraunces", "JetBrains Mono" — remote font host, expected.
+
+## Re-sync risks (watch-list)
+- **`dtsPropsFor` can drift**: it's hand-maintained. If a component's props
+  change in `src/`, the synced `.d.ts` won't follow automatically — update
+  `cfg.dtsPropsFor`.
+- **`conventions.md` names are tied to source**: the enumerated tokens come
+  from `src/styles/base/variables.css` and the variant strings from each
+  component's `variant` map. If those change, re-validate the header (the
+  conventions step does this automatically and reports drift).
+- **`RatingGraph.tsx` inlines sample `contests` data** — purely illustrative;
+  no upstream link to keep in sync.
+- **Build assumes network**: `build-css.mjs` prepends a remote Google Fonts
+  `@import`; fonts only resolve when the consuming environment has network.
+- Toolchain: built with Node + the repo's esbuild (0.28.1 override), playwright
+  chromium v1228.

--- a/.design-sync/build-css.mjs
+++ b/.design-sync/build-css.mjs
@@ -1,0 +1,27 @@
+// Flatten the design system's CSS for /design-sync.
+// The repo's `src/styles/index.css` is a tree of relative @imports; the
+// converter copies cfg.cssEntry verbatim to the bundle root, where those
+// relative paths would dangle. esbuild bundles them into one flat file with
+// the global class names intact (no CSS modules in this repo). The Google
+// Fonts @import is prepended so the brand families (Fraunces, JetBrains Mono)
+// — which the app loads from a <link> in index.html, not from CSS — load at
+// runtime for every design built with this DS.
+import { build } from 'esbuild';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const GOOGLE_FONTS =
+  '@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,300..900,0..100&family=JetBrains+Mono:wght@400;500&display=swap");\n';
+
+const OUT = '.design-sync/styles.bundled.css';
+
+await build({
+  entryPoints: ['src/styles/index.css'],
+  bundle: true,
+  outfile: OUT,
+  logLevel: 'warning',
+  loader: { '.svg': 'dataurl', '.png': 'dataurl', '.woff': 'dataurl', '.woff2': 'dataurl' },
+});
+
+const css = readFileSync(OUT, 'utf8');
+writeFileSync(OUT, GOOGLE_FONTS + css);
+console.error(`css: flattened src/styles/index.css → ${OUT} (${(css.length / 1024).toFixed(0)} KB)`);

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,27 @@
+{
+  "pkg": "simon-chen-website",
+  "globalName": "SimonChenWebsite",
+  "shape": "package",
+  "projectId": "1946e533-a140-4dd6-8579-51826a9a102c",
+  "entry": ".design-sync/entry.jsx",
+  "buildCmd": "node .design-sync/build-css.mjs",
+  "srcDir": "src",
+  "cssEntry": ".design-sync/styles.bundled.css",
+  "provider": { "component": "ThemeProvider" },
+  "guidelinesGlob": [],
+  "readmeHeader": ".design-sync/conventions.md",
+  "componentSrcMap": {
+    "Button": "src/components/ui/Button.jsx",
+    "Card": "src/components/ui/Card.jsx",
+    "Tag": "src/components/ui/Tag.jsx",
+    "FormField": "src/components/ui/FormField.jsx",
+    "RatingGraph": "src/components/charts/RatingGraph.jsx"
+  },
+  "dtsPropsFor": {
+    "Button": "variant?: 'primary' | 'secondary' | 'submit'; size?: 'small' | 'medium' | 'large'; type?: 'button' | 'submit' | 'reset'; disabled?: boolean; onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void; className?: string; children?: React.ReactNode;",
+    "Card": "variant?: 'default' | 'blog' | 'submission' | 'contest' | 'experience'; hover?: boolean; className?: string; children?: React.ReactNode;",
+    "Tag": "variant?: 'default' | 'skill' | 'tech' | 'rating' | 'verdict'; color?: string; className?: string; children?: React.ReactNode;",
+    "FormField": "label?: string; type?: string; name?: string; value?: string; onChange?: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void; placeholder?: string; required?: boolean; rows?: number; className?: string;",
+    "RatingGraph": "contests: Array<{ ratingUpdateTimeSeconds: number; newRating: number; contestName: string; contestId: number }>;"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,89 @@
+# Simon Chen Website — design system conventions
+
+An **editorial, warm-paper aesthetic**: square corners (`border-radius: 0`),
+hairline borders, a Fraunces serif for display/body and JetBrains Mono for
+code. Light theme is the default; a dark theme is available.
+
+## Setup — wrap the tree in ThemeProvider
+
+Every screen must be wrapped in `ThemeProvider`:
+
+```jsx
+const { ThemeProvider, Button, Card, Tag } = window.SimonChenWebsite;
+
+<ThemeProvider>
+  <main style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)', fontFamily: 'var(--font-serif)' }}>
+    {/* ... */}
+  </main>
+</ThemeProvider>
+```
+
+- `ThemeProvider` toggles a `light` / `dark` class on `<html>` and is what
+  `RatingGraph` reads via context — **`RatingGraph` throws without it.** The
+  other components render styled even unwrapped (tokens are defined on `:root`),
+  but always wrap so theming and chart components work.
+- The library does **not** paint a page background; set
+  `background: var(--bg-primary)` and `color: var(--text-primary)` on your root.
+
+## Styling idiom — variant props + CSS custom properties
+
+This is a **class-based** system, but you rarely write class names. Each
+component takes a `variant` prop that selects its look; for your own layout
+glue, style with the design tokens (`var(--*)`), never hard-coded colors.
+
+Component variants (use these exact strings):
+
+- **Button** — `variant`: `primary` (dark fill) · `secondary` (outline) ·
+  `submit` (full-width). Also `disabled`, `type`, `onClick`, `className`.
+- **Card** — thin container; `variant`: `default` · `blog` · `submission` ·
+  `contest` · `experience`. The visible style is a bottom rule (or left rule for
+  `experience`); put editorial markup inside.
+- **Tag** — `variant`: `default` · `skill` · `tech` · `rating` · `verdict`.
+  `rating`/`verdict` accept a `color` prop (drives a `currentColor` border).
+- **FormField** — labeled `input` or `textarea` (`type="textarea"`); props
+  `label`, `name`, `value`, `onChange`, `type`, `placeholder`, `required`,
+  `rows`. Underline inputs, no boxes.
+- **RatingGraph** — recharts line chart; `contests`: array of
+  `{ ratingUpdateTimeSeconds, newRating, contestName, contestId }`.
+
+## Design tokens (CSS custom properties)
+
+Use these for all surfaces, text, borders, and type — they re-theme for dark
+mode automatically:
+
+- Surfaces: `--bg-primary` `--bg-secondary` `--bg-tertiary` `--card-bg`
+  `--code-bg` `--hover-bg` `--stripe-bg`
+- Text: `--text-primary` `--text-secondary` `--text-muted` `--text-tertiary`
+- Lines: `--border-color` `--border-light`
+- Accent / status: `--accent-color` `--accent-bg` `--success-color`
+  `--error-color`
+- Type: `--font-serif` (Fraunces) · `--font-mono` (JetBrains Mono)
+
+## Where the truth lives
+
+- `styles.css` (it `@import`s `_ds_bundle.css`) — the full token + component
+  stylesheet. Read it before styling.
+- Each component's `<Name>.prompt.md` and `<Name>.d.ts` — props and usage.
+
+## Idiomatic example
+
+```jsx
+const { ThemeProvider, Card, Tag, Button } = window.SimonChenWebsite;
+
+<ThemeProvider>
+  <section style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)',
+                    fontFamily: 'var(--font-serif)', padding: '3rem', display: 'grid', gap: '2rem' }}>
+    <Card variant="blog">
+      <h3 className="blog-title">Building Spark Bytes</h3>
+      <p className="blog-excerpt" style={{ color: 'var(--text-secondary)' }}>
+        A campus food-sharing app that cut event waste.
+      </p>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <Tag variant="tech">React</Tag>
+        <Tag variant="tech">Node.js</Tag>
+      </div>
+    </Card>
+    <Button variant="primary" onClick={() => {}}>Read more</Button>
+  </section>
+</ThemeProvider>
+```

--- a/.design-sync/entry.jsx
+++ b/.design-sync/entry.jsx
@@ -1,0 +1,11 @@
+// Design-system barrel entry for /design-sync.
+// The repo's components are `export default`, which `export *` does NOT
+// re-export — so we re-export each as a named export here. ThemeProvider is
+// included because RatingGraph reads theme via useTheme() and the preview
+// provider (cfg.provider) must be a bundle export.
+export { default as Button } from '../src/components/ui/Button.jsx';
+export { default as Card } from '../src/components/ui/Card.jsx';
+export { default as Tag } from '../src/components/ui/Tag.jsx';
+export { default as FormField } from '../src/components/ui/FormField.jsx';
+export { default as RatingGraph } from '../src/components/charts/RatingGraph.jsx';
+export { ThemeProvider } from '../src/contexts/ThemeContext.jsx';

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,32 @@
+import { Button } from 'simon-chen-website';
+
+// Buttons drive the hero CTAs and the contact form (see Hero.jsx, Contact.jsx).
+// Editorial style: square corners, thin borders, serif label.
+
+export const Primary = () => (
+  <Button variant="primary" onClick={() => {}}>
+    View Projects
+  </Button>
+);
+
+export const Secondary = () => (
+  <Button variant="secondary" onClick={() => {}}>
+    Let&rsquo;s Chat
+  </Button>
+);
+
+export const Submit = () => (
+  <div style={{ maxWidth: 360 }}>
+    <Button type="submit" variant="submit">
+      Send Message
+    </Button>
+  </div>
+);
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <Button type="submit" variant="submit" disabled>
+      Sending&hellip;
+    </Button>
+  </div>
+);

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,56 @@
+import { Card } from 'simon-chen-website';
+
+// Card is a thin container — the visible style comes from its variant class
+// plus editorial child markup. Compositions mirror Blog.jsx (blog) and the
+// project/experience listings.
+
+export const Blog = () => (
+  <div style={{ maxWidth: 520 }}>
+    <Card variant="blog">
+      <h3 className="blog-title">Building Spark Bytes</h3>
+      <div className="blog-meta">
+        <span>Mar 14, 2025</span>
+        <span>&bull;</span>
+        <span>6 min read</span>
+        <span>&bull;</span>
+        <span>Engineering</span>
+      </div>
+      <p className="blog-excerpt">
+        How we built a campus food-sharing app that cut event waste while
+        feeding hundreds of students each week.
+      </p>
+      <a href="#" className="blog-link">
+        Read More
+      </a>
+    </Card>
+  </div>
+);
+
+export const Project = () => (
+  <div style={{ maxWidth: 520 }}>
+    <Card variant="default">
+      <h3 className="blog-title">Crime Mapper Boston</h3>
+      <p className="blog-excerpt">
+        An interactive map visualizing Boston crime data with filtering by
+        district, category, and time of day.
+      </p>
+    </Card>
+  </div>
+);
+
+export const Experience = () => (
+  <div style={{ maxWidth: 520 }}>
+    <Card variant="experience">
+      <h3 className="blog-title">Software Engineer Intern</h3>
+      <div className="blog-meta">
+        <span>Summer 2025</span>
+        <span>&bull;</span>
+        <span>Boston, MA</span>
+      </div>
+      <p className="blog-excerpt">
+        Shipped data pipelines and internal tooling for a real-time analytics
+        platform.
+      </p>
+    </Card>
+  </div>
+);

--- a/.design-sync/previews/FormField.tsx
+++ b/.design-sync/previews/FormField.tsx
@@ -1,0 +1,39 @@
+import { FormField } from 'simon-chen-website';
+
+// FormField renders a labeled input or textarea (type="textarea"). Inputs are
+// full-width with a bottom-border underline; see Contact.jsx. Static previews
+// pass a value + no-op onChange so the controlled field renders filled.
+
+const noop = () => {};
+
+export const Text = () => (
+  <div style={{ maxWidth: 420 }}>
+    <FormField label="Name" type="text" name="name" value="Ada Lovelace" onChange={noop} required />
+  </div>
+);
+
+export const Email = () => (
+  <div style={{ maxWidth: 420 }}>
+    <FormField label="Email" type="email" name="email" value="ada@example.com" onChange={noop} required />
+  </div>
+);
+
+export const Textarea = () => (
+  <div style={{ maxWidth: 420 }}>
+    <FormField
+      label="Message"
+      type="textarea"
+      name="message"
+      rows={5}
+      value="I'd love to chat about a collaboration on an open-source project."
+      onChange={noop}
+      required
+    />
+  </div>
+);
+
+export const Empty = () => (
+  <div style={{ maxWidth: 420 }}>
+    <FormField label="Subject" type="text" name="subject" placeholder="What's this about?" value="" onChange={noop} />
+  </div>
+);

--- a/.design-sync/previews/RatingGraph.tsx
+++ b/.design-sync/previews/RatingGraph.tsx
@@ -1,0 +1,39 @@
+import { RatingGraph } from 'simon-chen-website';
+
+// Recharts line chart of Codeforces rating history (see CodeforcesPreview.jsx).
+// It reads theme tokens via getComputedStyle and renders inside a
+// ResponsiveContainer, so the preview gives it an explicit width to size into.
+//
+// The capture harness freezes the clock, which stalls recharts' rAF-driven
+// line animation mid-draw. Drive rAF with an ever-advancing timestamp so the
+// chart settles to its final frame for a faithful static capture. This affects
+// only this preview card's page; designs the agent builds import the component
+// fresh and animate normally.
+if (typeof window !== 'undefined' && !(window as { __rgSettle?: boolean }).__rgSettle) {
+  (window as { __rgSettle?: boolean }).__rgSettle = true;
+  let t = 0;
+  window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+    t += 100000;
+    Promise.resolve().then(() => cb(t));
+    return 0;
+  };
+}
+
+const day = 86400;
+const base = Math.floor(new Date('2024-01-07').getTime() / 1000);
+const contests = [
+  { contestId: 1901, contestName: 'Codeforces Round 918 (Div. 4)', newRating: 1187, ratingUpdateTimeSeconds: base },
+  { contestId: 1915, contestName: 'Codeforces Round 919 (Div. 2)', newRating: 1264, ratingUpdateTimeSeconds: base + day * 21 },
+  { contestId: 1927, contestName: 'Educational Codeforces Round 162', newRating: 1342, ratingUpdateTimeSeconds: base + day * 49 },
+  { contestId: 1933, contestName: 'Codeforces Round 925 (Div. 3)', newRating: 1298, ratingUpdateTimeSeconds: base + day * 70 },
+  { contestId: 1941, contestName: 'Codeforces Round 929 (Div. 3)', newRating: 1405, ratingUpdateTimeSeconds: base + day * 98 },
+  { contestId: 1955, contestName: 'Codeforces Round 938 (Div. 3)', newRating: 1521, ratingUpdateTimeSeconds: base + day * 133 },
+  { contestId: 1969, contestName: 'Educational Codeforces Round 165', newRating: 1487, ratingUpdateTimeSeconds: base + day * 168 },
+  { contestId: 1985, contestName: 'Codeforces Round 952 (Div. 4)', newRating: 1603, ratingUpdateTimeSeconds: base + day * 203 },
+];
+
+export const Progression = () => (
+  <div style={{ width: 520, maxWidth: '100%' }}>
+    <RatingGraph contests={contests} />
+  </div>
+);

--- a/.design-sync/previews/Tag.tsx
+++ b/.design-sync/previews/Tag.tsx
@@ -1,0 +1,37 @@
+import { Tag } from 'simon-chen-website';
+
+// Tags label skills (About.jsx) and tech stacks (BlogPost.jsx); rating/verdict
+// variants color themselves via the `color` prop (currentColor border).
+
+export const Skills = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', maxWidth: 460 }}>
+    <Tag variant="skill">React</Tag>
+    <Tag variant="skill">JavaScript</Tag>
+    <Tag variant="skill">Python</Tag>
+    <Tag variant="skill">Machine Learning</Tag>
+    <Tag variant="skill">Rust</Tag>
+  </div>
+);
+
+export const Tech = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', maxWidth: 460 }}>
+    <Tag variant="tech">Node.js</Tag>
+    <Tag variant="tech">PostgreSQL</Tag>
+    <Tag variant="tech">Docker</Tag>
+    <Tag variant="tech">AWS</Tag>
+  </div>
+);
+
+export const Rating = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+    <Tag variant="rating" color="#1f8a4c">1487</Tag>
+    <Tag variant="rating" color="#c8442a">1923</Tag>
+  </div>
+);
+
+export const Verdict = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+    <Tag variant="verdict" color="#2d6a4f">Accepted</Tag>
+    <Tag variant="verdict" color="#a83220">Wrong Answer</Tag>
+  </div>
+);


### PR DESCRIPTION
Imports this site's design system into the **Simon Chen Website DS** Claude Design project (`1946e533-a140-4dd6-8579-51826a9a102c`) and commits the reproducible sync inputs so future re-syncs are fast and deterministic.

## What's synced
5 components — `Button`, `Card`, `Tag`, `FormField` (general) and `RatingGraph` (charts) — each with authored, graded preview cards. The design agent now builds with the real compiled components, tokens, and fonts.

## Files (sync inputs only — machine state is gitignored)
- `config.json` — converter config: custom barrel entry, `componentSrcMap`, `ThemeProvider` provider, hand-written `dtsPropsFor`, flattened `cssEntry`
- `entry.jsx` — re-exports the `export default` components as named (synth-entry's `export *` drops defaults) + `ThemeProvider`
- `build-css.mjs` (`buildCmd`) — flattens `src/styles/index.css` and prepends the remote Google Fonts `@import`
- `conventions.md` — design-agent header (editorial idiom, tokens, variant props)
- `previews/*.tsx` — authored preview compositions
- `NOTES.md` — repo-specific gotchas + re-sync watch-list

## Notes
This is a Vite app (not a published library), so the converter ran in synth-entry mode with a custom barrel entry. Fonts (Fraunces, JetBrains Mono) load remotely → validate reports `[FONT_REMOTE]` (expected). Render check is clean, all cells graded good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)